### PR TITLE
Updated: Brighten BorderColorBrush

### DIFF
--- a/Source/Reloaded.WPF.Theme.Default/Theme/Default/Colours.xaml
+++ b/Source/Reloaded.WPF.Theme.Default/Theme/Default/Colours.xaml
@@ -12,7 +12,7 @@
 
     <Color x:Key="TransparentBorderColor">#004c4c4c</Color>
     <Color x:Key="BorderColorLight">#C0ffffff</Color>
-    <Color x:Key="BorderColor">#4c4c4c</Color>
+    <Color x:Key="BorderColor">#7c7c7c</Color>
     <Color x:Key="BorderColorDark">#333333</Color>
 
     <Color x:Key="TextColor">#ffffff</Color>


### PR DESCRIPTION
In support of https://github.com/Reloaded-Project/Reloaded-II/issues/500

Originally was going to split up BorderColorBrush but there's a LOT of implicit things linked to this field.
Did testing with R-II and overall pleased with this as a compromise.

# Before
![image](https://github.com/user-attachments/assets/5aa707c2-f831-4310-88e3-c3d6e514ea28)
<img width="755" alt="image" src="https://github.com/user-attachments/assets/67111bf2-40ff-4169-b768-d6e1ba9116a2">
![image](https://github.com/user-attachments/assets/4b217e35-41d2-4c8f-b581-bf914538c5c4)
![image](https://github.com/user-attachments/assets/74b6924a-787b-4413-b85e-e55e1e8b28c7)


# After
![image](https://github.com/user-attachments/assets/497593ef-8731-4938-891b-1bb23c0ea2d4)
<img width="755" alt="image" src="https://github.com/user-attachments/assets/f64daac0-648b-4e5c-8e52-99ead30bacf0">
![image](https://github.com/user-attachments/assets/926d835c-d063-4c10-a173-b2ff6d78ba5a)
![image](https://github.com/user-attachments/assets/54688137-7b90-4e78-8d8c-c9be54d9344c)
